### PR TITLE
Fix usage of _tolower in WorldInstance::getBasicGameType

### DIFF
--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -612,7 +612,7 @@ EGameType WorldInstance::getBasicGameType()
                                           {"world.zen", GT_Gothic1}};
 
     std::string lower;
-    std::transform(m_ZenFile.begin(), m_ZenFile.end(), lower.begin(), _tolower);
+    std::transform(m_ZenFile.begin(), m_ZenFile.end(), std::back_inserter(lower), ::tolower);
 
     if(m.find(lower) != m.end())
         return m[lower];


### PR DESCRIPTION
This does not compile on Clang/OS X. Could be perhaps fixed by including <ctype.h>, but it is probably better idea to use the C++-standard function instead of the obsolete one from POSIX.

Also fixes unrelated UB, related to assigning characters after the end of the string.