### PR TITLE
Added smart delay in menu navigation

### DIFF
--- a/src/engine/Input.h
+++ b/src/engine/Input.h
@@ -143,6 +143,7 @@ namespace Engine
 		static void setMouseLockCallback(std::function<void(bool /* lock */)> callback);
 
 		static const std::bitset<NUM_KEYS>& getKeysTriggered(){ return keyTriggered; }
+        static const std::bitset<NUM_KEYS>& getKeysState() { return keyState; }
 
 		static void clearTriggered();
 

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -644,19 +644,30 @@ class ExampleCubes : public /*entry::AppI*/ PLATFORM_CLASS
 
 	bool update() BX_OVERRIDE
 	{
-        for (int i = 0; i < NUM_KEYS; i++)
-        {
-            if (getKeysTriggered()[i])
+        std::map<int, UI::EInputAction> keyMap = {{GLFW_KEY_UP,     UI::IA_Up},
+                                                  {GLFW_KEY_DOWN,   UI::IA_Down},
+                                                  {GLFW_KEY_LEFT,   UI::IA_Left},
+                                                  {GLFW_KEY_RIGHT,  UI::IA_Right},
+                                                  {GLFW_KEY_ENTER,  UI::IA_Accept},
+                                                  {GLFW_KEY_ESCAPE, UI::IA_Close}};
+        for (int i = 0; i < NUM_KEYS; i++) {
+            if (getKeysTriggered()[i]) // If key has been triggered start the stopwatch
             {
-                std::map<int, UI::EInputAction> m = {   {GLFW_KEY_UP, UI::IA_Up}, 
-                                                        {GLFW_KEY_DOWN, UI::IA_Down},
-                                                        {GLFW_KEY_LEFT, UI::IA_Left}, 
-                                                        {GLFW_KEY_RIGHT, UI::IA_Right}, 
-                                                        {GLFW_KEY_ENTER, UI::IA_Accept},
-                                                        {GLFW_KEY_ESCAPE, UI::IA_Close} }; 
-
-                if(m.find(i) != m.end())
-                    m_pEngine->getHud().onInputAction(m[i]);
+                if (keyMap.find(i) != keyMap.end())
+                {
+                    m_pEngine->getHud().onInputAction(keyMap[i]);
+                    m_stopWatch.start();
+                }
+            }
+            else if (getKeysState()[i]) // If key is being held and stopwatch reached time limit, fire actions
+            {
+                if (m_stopWatch.getTimeDiffFromStartToNow() > 400)
+                {
+                    if (m_stopWatch.DelayedByArgMS(150))
+                    {
+                        m_pEngine->getHud().onInputAction(keyMap[i]);
+                    }
+                }
             }
         }
 
@@ -776,6 +787,7 @@ class ExampleCubes : public /*entry::AppI*/ PLATFORM_CLASS
 	int64_t m_timeOffset;
 	float axis;
     int32_t m_scrollArea;
+    Utils::StopWatch m_stopWatch;
 };
 
 //ENTRY_IMPLEMENT_MAIN(ExampleCubes);

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -255,3 +255,30 @@ namespace Utils
         return fileName.substr(0, dp);
     }
 }
+
+void Utils::StopWatch::start()
+{
+    m_begin = m_delayTimeStamp = Utils::currentTimestamp();
+    m_stopped = false;
+}
+
+void Utils::StopWatch::stop()
+{
+    m_end = Utils::currentTimestamp();
+    m_stopped = true;
+}
+
+int Utils::StopWatch::getTimeDiffFromStartToNow()
+{
+    return Utils::currentTimestamp() - m_begin;
+}
+
+bool Utils::StopWatch::DelayedByArgMS(int delay)
+{
+    if (Utils::currentTimestamp() - m_delayTimeStamp > delay)
+    {
+        m_delayTimeStamp = Utils::currentTimestamp();
+        return true;
+    }
+    else return false;
+}

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -174,6 +174,39 @@ namespace Utils
     }
 
     /**
+     * Simple class for calculating elapsed time from start() to stop()
+     */
+    class StopWatch
+    {
+    public:
+        StopWatch () : m_begin(0), m_end(0), m_delayTimeStamp(0), m_stopped(true) {}
+        /**
+         * Start checkpoint
+         */
+        void start();
+        /**
+         * End checkpoint
+         */
+        void stop();
+        /**
+         * Returns time difference in seconds between start and now
+         */
+        int getTimeDiffFromStartToNow();
+
+        bool isStopped() { return m_stopped; }
+        /**
+         * Returns true if delay amount of milliseconds have passed since previous invocation, false otherwise
+         */
+        bool DelayedByArgMS(int delay);
+
+    private:
+        long long m_begin;
+        long long m_end;
+        long long m_delayTimeStamp;
+        bool m_stopped;
+    };
+
+    /**
      * Iterates through the given directory and calls fn for each file
      * @param directory path to directory to interate through
      * @param fn function to call for each file. Arguments: full path, filename, ext


### PR DESCRIPTION
Added smart delay which reveals itself when holding (rather than triggering) a button in menus (dialog, main..). This imitates the behavior of menu navigation in the original game, although the introduced delays may require adjustment to better reflect original Gothic's experience.