### PR TITLE
Aqua

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -67,9 +67,9 @@ SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles: true
 SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: true
-SpacesInParentheses: true
-SpacesInSquareBrackets: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
 Standard: Cpp11
 TabWidth: 4
 UseTab: Never

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,75 @@
+Language: Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      false
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit: 0
+CommentPragmas: '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros: [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IndentCaseLabels: true
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+PenaltyBreakBeforeFirstCallParameter: 100
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 10000
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: false
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: true
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: true
+SpacesInParentheses: true
+SpacesInSquareBrackets: true
+Standard: Cpp11
+TabWidth: 4
+UseTab: Never

--- a/src/content/Materials.h
+++ b/src/content/Materials.h
@@ -6,6 +6,20 @@
 namespace Materials
 {
     /**
+     * Enums defining material group
+     */
+    // FIXME names below need to be changed most likely
+    enum MaterialGroup
+    {
+       UNDEFINED,
+       PLACEHOLDER1,
+       PLACEHOLDER2,
+       PLACEHOLDER3,
+       GROUND,
+       WATER
+    };
+
+    /**
      * Base material-structure
      * Defines handle-type and other needed properties
      */

--- a/src/content/StaticMeshAllocator.cpp
+++ b/src/content/StaticMeshAllocator.cpp
@@ -29,7 +29,7 @@ StaticMeshAllocator::~StaticMeshAllocator()
     }
 }
 
-
+#include <bitset>
 Handle::MeshHandle StaticMeshAllocator::loadFromPackedSubmesh(const ZenLoad::PackedMesh& packed, size_t submesh, const std::string& name)
 {
     // Create mesh instance
@@ -53,7 +53,6 @@ Handle::MeshHandle StaticMeshAllocator::loadFromPackedSubmesh(const ZenLoad::Pac
     mesh.mesh.m_SubmeshMaterials.back().m_TextureName = m.material.texture;
     mesh.mesh.m_SubmeshMaterials.back().m_NoCollision = m.material.noCollDet;
     mesh.mesh.m_SubmeshMaterialNames.push_back(m.material.texture);
-
     // Construct BGFX Vertex/Index-buffers
     mesh.mesh.m_VertexBufferHandle = bgfx::createVertexBuffer(
             // Static data can be passed with bgfx::makeRef

--- a/src/content/StaticMeshAllocator.cpp
+++ b/src/content/StaticMeshAllocator.cpp
@@ -29,7 +29,6 @@ StaticMeshAllocator::~StaticMeshAllocator()
     }
 }
 
-#include <bitset>
 Handle::MeshHandle StaticMeshAllocator::loadFromPackedSubmesh(const ZenLoad::PackedMesh& packed, size_t submesh, const std::string& name)
 {
     // Create mesh instance

--- a/src/engine/WorldMesh.cpp
+++ b/src/engine/WorldMesh.cpp
@@ -36,18 +36,18 @@ float WorldMesh::interpolateTriangleShadowValue(size_t triangleIdx, const Math::
 	return (u * c[0] + v * c[1] + w * c[2]).x; // Lighting is greyscale only
 }
 
-void WorldMesh::getTriangle( size_t triangleIdx, Math::float3* v3, uint8_t& matgroup )
+void WorldMesh::getTriangle(size_t triangleIdx, Math::float3* v3, uint8_t& matgroup)
 {
-    assert( triangleIdx < m_WorldMeshData.triangles.size() );
-    ZenLoad::WorldTriangle& tri = m_WorldMeshData.triangles[ triangleIdx ];
-    matgroup = m_WorldMeshData.subMeshes[ tri.submeshIndex ].material.matGroup;
+    assert(triangleIdx < m_WorldMeshData.triangles.size());
+    ZenLoad::WorldTriangle& tri = m_WorldMeshData.triangles[triangleIdx];
+    matgroup = m_WorldMeshData.subMeshes[tri.submeshIndex].material.matGroup;
 
-    for ( int i = 0; i < 3; i++ )
-        v3[ i ] = Math::float3( tri.vertices[ i ].Position.v );
+    for (int i = 0; i < 3; i++)
+        v3[i] = Math::float3(tri.vertices[i].Position.v);
 }
 
-ZenLoad::zCMaterialData WorldMesh::GetMatData( size_t triangleIdx )
+ZenLoad::zCMaterialData WorldMesh::GetMatData(size_t triangleIdx)
 {
-    assert( triangleIdx < m_WorldMeshData.triangles.size() );
-    return m_WorldMeshData.subMeshes[m_WorldMeshData.triangles[ triangleIdx ].submeshIndex].material;
+    assert(triangleIdx < m_WorldMeshData.triangles.size());
+    return m_WorldMeshData.subMeshes[m_WorldMeshData.triangles[triangleIdx].submeshIndex].material;
 }

--- a/src/engine/WorldMesh.cpp
+++ b/src/engine/WorldMesh.cpp
@@ -46,7 +46,7 @@ void WorldMesh::getTriangle(size_t triangleIdx, Math::float3* v3, uint8_t& matgr
         v3[i] = Math::float3(tri.vertices[i].Position.v);
 }
 
-ZenLoad::zCMaterialData WorldMesh::GetMatData(size_t triangleIdx)
+ZenLoad::zCMaterialData WorldMesh::getMatData(size_t triangleIdx)
 {
     assert(triangleIdx < m_WorldMeshData.triangles.size());
     return m_WorldMeshData.subMeshes[m_WorldMeshData.triangles[triangleIdx].submeshIndex].material;

--- a/src/engine/WorldMesh.cpp
+++ b/src/engine/WorldMesh.cpp
@@ -36,13 +36,18 @@ float WorldMesh::interpolateTriangleShadowValue(size_t triangleIdx, const Math::
 	return (u * c[0] + v * c[1] + w * c[2]).x; // Lighting is greyscale only
 }
 
-void WorldMesh::getTriangle(size_t triangleIdx, Math::float3 *v3)
+void WorldMesh::getTriangle( size_t triangleIdx, Math::float3* v3, uint8_t& matgroup )
 {
-	assert(triangleIdx < m_WorldMeshData.triangles.size());
+    assert( triangleIdx < m_WorldMeshData.triangles.size() );
+    ZenLoad::WorldTriangle& tri = m_WorldMeshData.triangles[ triangleIdx ];
+    matgroup = m_WorldMeshData.subMeshes[ tri.submeshIndex ].material.matGroup;
 
-	ZenLoad::WorldTriangle& tri = m_WorldMeshData.triangles[triangleIdx];
-
-	for(int i=0;i<3;i++)
-		v3[i] = Math::float3(tri.vertices[i].Position.v);
+    for ( int i = 0; i < 3; i++ )
+        v3[ i ] = Math::float3( tri.vertices[ i ].Position.v );
 }
 
+ZenLoad::zCMaterialData WorldMesh::GetMatData( size_t triangleIdx )
+{
+    assert( triangleIdx < m_WorldMeshData.triangles.size() );
+    return m_WorldMeshData.subMeshes[m_WorldMeshData.triangles[ triangleIdx ].submeshIndex].material;
+}

--- a/src/engine/WorldMesh.h
+++ b/src/engine/WorldMesh.h
@@ -47,7 +47,7 @@ namespace World
 		/**
 		 * Debugging purposes only
 		 */
-		ZenLoad::zCMaterialData GetMatData(size_t triangleIdx);
+		ZenLoad::zCMaterialData getMatData(size_t triangleIdx);
 
 	protected:
 

--- a/src/engine/WorldMesh.h
+++ b/src/engine/WorldMesh.h
@@ -33,15 +33,22 @@ namespace World
 		/**
 		 * Returns the vertices of the given triangle
 		 * @param triangleIdx Triangle to get the vertices from
-		 * @param v3 pointer to array fo 3 Math::float3s
+		 * @param v3 pointer to array of 3 Math::float3s
+		 * @param matgroup bitmap holding material group info for this triangle
 		 */
-		void getTriangle(size_t triangleIdx, Math::float3* v3);
+		void getTriangle(size_t triangleIdx, Math::float3 *v3, uint8_t& matgroup);
 
 		/**
 		 * @return Boundingbox max/min
 		 */
 		const Math::float3& getBBoxMin(){ return m_BBox3d[0]; }
 		const Math::float3& getBBoxMax(){ return m_BBox3d[1]; }
+
+		/**
+		 * Debugging purposes only
+		 */
+		ZenLoad::zCMaterialData GetMatData(size_t triangleIdx);
+
 	protected:
 
 		/**

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -299,29 +299,34 @@ void PlayerController::onDebugDraw()
         Render::debugDrawPath(m_World.getWaynet(), m_MoveState.currentPath);
     }
 
-
-    /*Math::float3 to = getEntityTransform().Translation() + Math::float3(0.0f, -100.0f, 0.0f);
-    Math::float3 from = getEntityTransform().Translation() + Math::float3(0.0f, 0.0f, 0.0f);
-
-    Physics::RayTestResult hit = m_World.getPhysicsSystem().raytrace(from, to, Physics::CollisionShape::CT_WorldMesh);
-
-    if (hit.hasHit)
-    {
-        ddDrawAxis(hit.hitPosition.x, hit.hitPosition.y, hit.hitPosition.z);
-
-        float shadow = m_World.getWorldMesh().interpolateTriangleShadowValue(hit.hitTriangleIndex, hit.hitPosition);
-
-        if(getModelVisual())
-            getModelVisual()->setShadowValue(shadow);
-
-        Math::float3 v3[3];
-        m_World.getWorldMesh().getTriangle(hit.hitTriangleIndex, v3);
-
-        for(int i=0;i<3;i++)
-        {
-            ddDrawAxis(v3[i].x, v3[i].y, v3[i].z);
-        }
-    }*/
+    // Math::float3 to = getEntityTransform().Translation() + Math::float3(0.0f, -1.0f, 0.0f);
+    // Math::float3 from = getEntityTransform().Translation() + Math::float3(0.0f, 1.0f, 0.0f);
+    //
+    // Physics::RayTestResult hit = m_World.getPhysicsSystem().raytrace(from, to, Physics::CollisionShape::CT_WorldMesh);
+    //
+    // if (hit.hasHit)
+    // {
+    //     ddDrawAxis(hit.hitPosition.x, hit.hitPosition.y, hit.hitPosition.z);
+    //
+    //     float shadow = m_World.getWorldMesh().interpolateTriangleShadowValue(hit.hitTriangleIndex, hit.hitPosition);
+    //
+    //     if(getModelVisual())
+    //         getModelVisual()->setShadowValue(shadow);
+    //
+    //     Math::float3 v3[3];
+    //     ZenLoad::zCMaterialData data = m_World.getWorldMesh().GetMatData(hit.hitTriangleIndex);
+    //     uint8_t matgroup;
+    //     m_World.getWorldMesh().getTriangle(hit.hitTriangleIndex, v3, matgroup);
+    //     // if (isPlayerControlled())
+    //     // {
+    //     //    LogInfo() << "matgroup : " << std::bitset<8>(data.matGroup);
+    //     //    LogInfo() << "matname: " << data.matName;
+    //     // }
+    //     for(int i=0;i<3;i++)
+    //     {
+    //         ddDrawAxis(v3[i].x, v3[i].y, v3[i].z);
+    //     }
+    // }
 
     if (isPlayerControlled())
     {
@@ -786,13 +791,13 @@ void PlayerController::onUpdateByInput(float deltaTime)
         }
     });
     */
-    if (m_isDrawWeaponMelee)
+    if ( m_isDrawWeaponMelee )
     {
-        if (!lastDraw)
+        if ( !lastDraw )
         {
             lastDraw = true;
 
-            if (m_EquipmentState.activeWeapon.isValid())
+            if ( m_EquipmentState.activeWeapon.isValid() )
                 undrawWeapon();
             else
                 drawWeaponMelee();
@@ -800,105 +805,112 @@ void PlayerController::onUpdateByInput(float deltaTime)
 
         // Don't overwrite the drawing animation
         return;
-    } else if (!m_isDrawWeaponMelee && lastDraw)
+    }
+    else if ( !m_isDrawWeaponMelee && lastDraw )
     {
         lastDraw = false;
     }
-
+      
     m_NoAniRootPosHack = false;
-    if (m_EquipmentState.weaponMode == EWeaponMode::WeaponNone)
+
+    if ( m_EquipmentState.weaponMode == EWeaponMode::WeaponNone )
     {
         static std::string lastMovementAni = "";
-        if (m_isStrafeLeft)
-        {
-            model->setAnimation(ModelVisual::EModelAnimType::StrafeLeft);
+        static auto ManageAnimation = [&]( auto groundAniType, auto waterAniType ) {
+            if ( getSurfaceMaterial() == Materials::MaterialGroup::WATER )
+            {
+                model->setAnimation( waterAniType );
+            }
+            else if ( getSurfaceMaterial() == Materials::MaterialGroup::GROUND )
+            {
+                model->setAnimation( groundAniType );
+            }
             lastMovementAni = getModelVisual()->getAnimationHandler().getActiveAnimationPtr()->getModelAniHeader().aniName;
             m_NoAniRootPosHack = true;
-        } else if (m_isStrafeRight)
+        };
+        if ( m_isStrafeLeft )
         {
-            model->setAnimation(ModelVisual::EModelAnimType::StrafeRight);
-            lastMovementAni = getModelVisual()->getAnimationHandler().getActiveAnimationPtr()->getModelAniHeader().aniName;
-            m_NoAniRootPosHack = true;
-        } else if (m_isForward)
-        {
-            model->setAnimation(ModelVisual::EModelAnimType::Run);
-            lastMovementAni = getModelVisual()->getAnimationHandler().getActiveAnimationPtr()->getModelAniHeader().aniName;
-            m_NoAniRootPosHack = true;
-        } else if (m_isBackward)
-        {
-            model->setAnimation(ModelVisual::EModelAnimType::Backpedal);
-            lastMovementAni = getModelVisual()->getAnimationHandler().getActiveAnimationPtr()->getModelAniHeader().aniName;
-            m_NoAniRootPosHack = true;
+            ManageAnimation( ModelVisual::EModelAnimType::StrafeRight, ModelVisual::EModelAnimType::SwimTurnLeft );
         }
-//		else if(inputGetKeyState(entry::Key::KeyQ))
-//		{
-//			model->setAnimation(ModelVisual::EModelAnimType::AttackFist);
-//		}
-        else if (getModelVisual()->getAnimationHandler().getActiveAnimationPtr()
-                 && getModelVisual()->getAnimationHandler().getActiveAnimationPtr()->getModelAniHeader().aniName ==
-                    lastMovementAni)
+        else if ( m_isStrafeRight )
         {
-            model->setAnimation(ModelVisual::Idle);
+            ManageAnimation( ModelVisual::EModelAnimType::StrafeRight, ModelVisual::EModelAnimType::SwimTurnRight );
+        }
+        else if ( m_isForward )
+        {
+            ManageAnimation( ModelVisual::EModelAnimType::Run, ModelVisual::EModelAnimType::SwimF );
+        }
+        else if ( m_isBackward )
+        {
+            ManageAnimation( ModelVisual::EModelAnimType::Backpedal, ModelVisual::EModelAnimType::SwimB );
+        }
+        //		else if(inputGetKeyState(entry::Key::KeyQ))
+        //		{
+        //			model->setAnimation(ModelVisual::EModelAnimType::AttackFist);
+        //		}
+        else if ( getModelVisual()->getAnimationHandler().getActiveAnimationPtr() && getModelVisual()->getAnimationHandler().getActiveAnimationPtr()->getModelAniHeader().aniName == lastMovementAni )
+        {
+            ManageAnimation( ModelVisual::EModelAnimType::Idle, ModelVisual::EModelAnimType::Swim );
             m_NoAniRootPosHack = true;
         }
     }
-//	else
-//	{
-//        std::map<EWeaponMode, std::vector<ModelVisual::EModelAnimType>> aniMap =
-//                {
-//                        {EWeaponMode::Weapon1h, {       ModelVisual::EModelAnimType::Attack1h_L,
-//                                                        ModelVisual::EModelAnimType::Attack1h_R,
-//                                                        ModelVisual::EModelAnimType::Run1h,
-//                                                        ModelVisual::EModelAnimType::Backpedal1h,
-//                                                        ModelVisual::EModelAnimType::Attack1h,
-//                                                        ModelVisual::EModelAnimType::Idle1h}},
+    //	else
+    //	{
+    //        std::map<EWeaponMode, std::vector<ModelVisual::EModelAnimType>> aniMap =
+    //                {
+    //                        {EWeaponMode::Weapon1h, {       ModelVisual::EModelAnimType::Attack1h_L,
+    //                                                        ModelVisual::EModelAnimType::Attack1h_R,
+    //                                                        ModelVisual::EModelAnimType::Run1h,
+    //                                                        ModelVisual::EModelAnimType::Backpedal1h,
+    //                                                        ModelVisual::EModelAnimType::Attack1h,
+    //                                                        ModelVisual::EModelAnimType::Idle1h}},
 
-//                        {EWeaponMode::Weapon2h, {       ModelVisual::EModelAnimType::Attack2h_L,
-//                                                        ModelVisual::EModelAnimType::Attack2h_R,
-//                                                        ModelVisual::EModelAnimType::Run2h,
-//                                                        ModelVisual::EModelAnimType::Backpedal2h,
-//                                                        ModelVisual::EModelAnimType::Attack2h,
-//                                                        ModelVisual::EModelAnimType::Idle2h}},
+    //                        {EWeaponMode::Weapon2h, {       ModelVisual::EModelAnimType::Attack2h_L,
+    //                                                        ModelVisual::EModelAnimType::Attack2h_R,
+    //                                                        ModelVisual::EModelAnimType::Run2h,
+    //                                                        ModelVisual::EModelAnimType::Backpedal2h,
+    //                                                        ModelVisual::EModelAnimType::Attack2h,
+    //                                                        ModelVisual::EModelAnimType::Idle2h}},
 
-//                        {EWeaponMode::WeaponBow, {      ModelVisual::EModelAnimType::IdleBow,
-//                                                        ModelVisual::EModelAnimType::IdleBow,
-//                                                        ModelVisual::EModelAnimType::RunBow,
-//                                                        ModelVisual::EModelAnimType::BackpedalBow,
-//                                                        ModelVisual::EModelAnimType::AttackBow,
-//                                                        ModelVisual::EModelAnimType::IdleBow}},
+    //                        {EWeaponMode::WeaponBow, {      ModelVisual::EModelAnimType::IdleBow,
+    //                                                        ModelVisual::EModelAnimType::IdleBow,
+    //                                                        ModelVisual::EModelAnimType::RunBow,
+    //                                                        ModelVisual::EModelAnimType::BackpedalBow,
+    //                                                        ModelVisual::EModelAnimType::AttackBow,
+    //                                                        ModelVisual::EModelAnimType::IdleBow}},
 
-//                        {EWeaponMode::WeaponCrossBow, { ModelVisual::EModelAnimType::IdleCBow,
-//                                                        ModelVisual::EModelAnimType::IdleCBow,
-//                                                        ModelVisual::EModelAnimType::RunCBow,
-//                                                        ModelVisual::EModelAnimType::BackpedalCBow,
-//                                                        ModelVisual::EModelAnimType::AttackCBow,
-//                                                        ModelVisual::EModelAnimType::IdleCBow}}
-//                };
+    //                        {EWeaponMode::WeaponCrossBow, { ModelVisual::EModelAnimType::IdleCBow,
+    //                                                        ModelVisual::EModelAnimType::IdleCBow,
+    //                                                        ModelVisual::EModelAnimType::RunCBow,
+    //                                                        ModelVisual::EModelAnimType::BackpedalCBow,
+    //                                                        ModelVisual::EModelAnimType::AttackCBow,
+    //                                                        ModelVisual::EModelAnimType::IdleCBow}}
+    //                };
 
-//		if(inputGetKeyState(entry::Key::KeyA))
-//		{
-//			model->setAnimation(aniMap[m_EquipmentState.weaponMode][0]);
-//		}
-//		else if(inputGetKeyState(entry::Key::KeyD))
-//		{
-//            model->setAnimation(aniMap[m_EquipmentState.weaponMode][1]);
-//		}
-//		else if(inputGetKeyState(entry::Key::KeyW))
-//		{
-//            model->setAnimation(aniMap[m_EquipmentState.weaponMode][2]);
-//		}
-//		else if(inputGetKeyState(entry::Key::KeyS))
-//		{
-//            model->setAnimation(aniMap[m_EquipmentState.weaponMode][3]);
-//		}
-//		else if(inputGetKeyState(entry::Key::KeyQ))
-//		{
-//            model->setAnimation(aniMap[m_EquipmentState.weaponMode][4]);
-//		}
-//		else {
-//            model->setAnimation(aniMap[m_EquipmentState.weaponMode][5]);
-//		}
-//	}
+    //		if(inputGetKeyState(entry::Key::KeyA))
+    //		{
+    //			model->setAnimation(aniMap[m_EquipmentState.weaponMode][0]);
+    //		}
+    //		else if(inputGetKeyState(entry::Key::KeyD))
+    //		{
+    //            model->setAnimation(aniMap[m_EquipmentState.weaponMode][1]);
+    //		}
+    //		else if(inputGetKeyState(entry::Key::KeyW))
+    //		{
+    //            model->setAnimation(aniMap[m_EquipmentState.weaponMode][2]);
+    //		}
+    //		else if(inputGetKeyState(entry::Key::KeyS))
+    //		{
+    //            model->setAnimation(aniMap[m_EquipmentState.weaponMode][3]);
+    //		}
+    //		else if(inputGetKeyState(entry::Key::KeyQ))
+    //		{
+    //            model->setAnimation(aniMap[m_EquipmentState.weaponMode][4]);
+    //		}
+    //		else {
+    //            model->setAnimation(aniMap[m_EquipmentState.weaponMode][5]);
+    //		}
+    //	}
 
 
     float yaw = 0.0f;
@@ -2391,4 +2403,26 @@ void PlayerController::updateStatusScreen(UI::Menu_Status& statsScreen)
     statsScreen.setExperience(stats.exp);
     statsScreen.setExperienceNext(stats.exp_next);
     statsScreen.setLearnPoints(stats.lp);
+}
+
+Materials::MaterialGroup PlayerController::getSurfaceMaterial()
+{
+    Math::float3 to = getEntityTransform().Translation() + Math::float3( 0.0f, -3.0f, 0.0f );
+    Math::float3 from = getEntityTransform().Translation() + Math::float3( 0.0f, 1.0f, 0.0f );
+    // LogInfo() << "Initial position: " << (getEntityTransform().Translation()).x  << " " <<  (getEntityTransform().Translation()).y << " " <<  (getEntityTransform().Translation()).z;
+    // LogInfo() << "From: " << (from).x  << " " <<  (from).y << " " <<  (from).z;
+    // LogInfo() << "To: " << (to).x  << " " <<  (to).y << " " <<  (to).z;
+
+    Physics::RayTestResult hit = m_World.getPhysicsSystem().raytrace( from, to, Physics::CollisionShape::CT_WorldMesh ); // FIXME This is a hack for now
+
+    if ( hit.hasHit )
+    {
+        // LogInfo() << "Hit position: " << (hit.hitPosition).x  << " " <<  (hit.hitPosition).y << " " <<  (hit.hitPosition).z;
+        // if ((from - hit.hitPosition).y < 1) return Materials::MaterialGroup::GROUND;
+        Math::float3 v3[ 3 ];
+        uint8_t matgroup;
+        m_World.getWorldMesh().getTriangle( hit.hitTriangleIndex, v3, matgroup );
+        return static_cast< Materials::MaterialGroup >( matgroup );
+    }
+    return Materials::MaterialGroup::UNDEFINED;
 }

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -791,13 +791,13 @@ void PlayerController::onUpdateByInput(float deltaTime)
         }
     });
     */
-    if ( m_isDrawWeaponMelee )
+    if (m_isDrawWeaponMelee)
     {
-        if ( !lastDraw )
+        if (!lastDraw)
         {
             lastDraw = true;
 
-            if ( m_EquipmentState.activeWeapon.isValid() )
+            if (m_EquipmentState.activeWeapon.isValid())
                 undrawWeapon();
             else
                 drawWeaponMelee();
@@ -806,51 +806,51 @@ void PlayerController::onUpdateByInput(float deltaTime)
         // Don't overwrite the drawing animation
         return;
     }
-    else if ( !m_isDrawWeaponMelee && lastDraw )
+    else if (!m_isDrawWeaponMelee && lastDraw)
     {
         lastDraw = false;
     }
-      
+
     m_NoAniRootPosHack = false;
 
-    if ( m_EquipmentState.weaponMode == EWeaponMode::WeaponNone )
+    if (m_EquipmentState.weaponMode == EWeaponMode::WeaponNone)
     {
         static std::string lastMovementAni = "";
-        static auto ManageAnimation = [&]( auto groundAniType, auto waterAniType ) {
-            if ( getSurfaceMaterial() == Materials::MaterialGroup::WATER )
+        static auto ManageAnimation = [&](auto groundAniType, auto waterAniType) {
+            if (getSurfaceMaterial() == Materials::MaterialGroup::WATER)
             {
-                model->setAnimation( waterAniType );
+                model->setAnimation(waterAniType);
             }
-            else if ( getSurfaceMaterial() == Materials::MaterialGroup::GROUND )
+            else if (getSurfaceMaterial() == Materials::MaterialGroup::GROUND)
             {
-                model->setAnimation( groundAniType );
+                model->setAnimation(groundAniType);
             }
             lastMovementAni = getModelVisual()->getAnimationHandler().getActiveAnimationPtr()->getModelAniHeader().aniName;
             m_NoAniRootPosHack = true;
         };
-        if ( m_isStrafeLeft )
+        if (m_isStrafeLeft)
         {
-            ManageAnimation( ModelVisual::EModelAnimType::StrafeRight, ModelVisual::EModelAnimType::SwimTurnLeft );
+            ManageAnimation(ModelVisual::EModelAnimType::StrafeRight, ModelVisual::EModelAnimType::SwimTurnLeft);
         }
-        else if ( m_isStrafeRight )
+        else if (m_isStrafeRight)
         {
-            ManageAnimation( ModelVisual::EModelAnimType::StrafeRight, ModelVisual::EModelAnimType::SwimTurnRight );
+            ManageAnimation(ModelVisual::EModelAnimType::StrafeRight, ModelVisual::EModelAnimType::SwimTurnRight);
         }
-        else if ( m_isForward )
+        else if (m_isForward)
         {
-            ManageAnimation( ModelVisual::EModelAnimType::Run, ModelVisual::EModelAnimType::SwimF );
+            ManageAnimation(ModelVisual::EModelAnimType::Run, ModelVisual::EModelAnimType::SwimF);
         }
-        else if ( m_isBackward )
+        else if (m_isBackward)
         {
-            ManageAnimation( ModelVisual::EModelAnimType::Backpedal, ModelVisual::EModelAnimType::SwimB );
+            ManageAnimation(ModelVisual::EModelAnimType::Backpedal, ModelVisual::EModelAnimType::SwimB);
         }
         //		else if(inputGetKeyState(entry::Key::KeyQ))
         //		{
         //			model->setAnimation(ModelVisual::EModelAnimType::AttackFist);
         //		}
-        else if ( getModelVisual()->getAnimationHandler().getActiveAnimationPtr() && getModelVisual()->getAnimationHandler().getActiveAnimationPtr()->getModelAniHeader().aniName == lastMovementAni )
+        else if (getModelVisual()->getAnimationHandler().getActiveAnimationPtr() && getModelVisual()->getAnimationHandler().getActiveAnimationPtr()->getModelAniHeader().aniName == lastMovementAni)
         {
-            ManageAnimation( ModelVisual::EModelAnimType::Idle, ModelVisual::EModelAnimType::Swim );
+            ManageAnimation(ModelVisual::EModelAnimType::Idle, ModelVisual::EModelAnimType::Swim);
             m_NoAniRootPosHack = true;
         }
     }
@@ -2407,22 +2407,22 @@ void PlayerController::updateStatusScreen(UI::Menu_Status& statsScreen)
 
 Materials::MaterialGroup PlayerController::getSurfaceMaterial()
 {
-    Math::float3 to = getEntityTransform().Translation() + Math::float3( 0.0f, -3.0f, 0.0f );
-    Math::float3 from = getEntityTransform().Translation() + Math::float3( 0.0f, 1.0f, 0.0f );
+    Math::float3 to = getEntityTransform().Translation() + Math::float3(0.0f, -3.0f, 0.0f);
+    Math::float3 from = getEntityTransform().Translation() + Math::float3(0.0f, 1.0f, 0.0f);
     // LogInfo() << "Initial position: " << (getEntityTransform().Translation()).x  << " " <<  (getEntityTransform().Translation()).y << " " <<  (getEntityTransform().Translation()).z;
     // LogInfo() << "From: " << (from).x  << " " <<  (from).y << " " <<  (from).z;
     // LogInfo() << "To: " << (to).x  << " " <<  (to).y << " " <<  (to).z;
 
-    Physics::RayTestResult hit = m_World.getPhysicsSystem().raytrace( from, to, Physics::CollisionShape::CT_WorldMesh ); // FIXME This is a hack for now
+    Physics::RayTestResult hit = m_World.getPhysicsSystem().raytrace(from, to, Physics::CollisionShape::CT_WorldMesh); // FIXME This is a hack for now
 
-    if ( hit.hasHit )
+    if (hit.hasHit)
     {
         // LogInfo() << "Hit position: " << (hit.hitPosition).x  << " " <<  (hit.hitPosition).y << " " <<  (hit.hitPosition).z;
         // if ((from - hit.hitPosition).y < 1) return Materials::MaterialGroup::GROUND;
-        Math::float3 v3[ 3 ];
+        Math::float3 v3[3];
         uint8_t matgroup;
-        m_World.getWorldMesh().getTriangle( hit.hitTriangleIndex, v3, matgroup );
-        return static_cast< Materials::MaterialGroup >( matgroup );
+        m_World.getWorldMesh().getTriangle(hit.hitTriangleIndex, v3, matgroup);
+        return static_cast< Materials::MaterialGroup >(matgroup);
     }
     return Materials::MaterialGroup::UNDEFINED;
 }

--- a/src/logic/PlayerController.h
+++ b/src/logic/PlayerController.h
@@ -362,6 +362,11 @@ namespace Logic
         void updateStatusScreen(UI::Menu_Status& statsScreen);
 
         /**
+         * Returns material data on which the NPC is standing
+         */
+        Materials::MaterialGroup getSurfaceMaterial();
+
+        /**
          * @return Item this NPC is currently interacting with
          */
         Daedalus::GameState::ItemHandle getInteractItem(){ return Daedalus::GameState::ItemHandle(); /* TODO: Implement */ }

--- a/src/logic/PlayerController.h
+++ b/src/logic/PlayerController.h
@@ -233,6 +233,11 @@ namespace Logic
         void placeOnGround();
 
         /**
+         * Saves data of the ground on which the NPC is standing
+         */
+        void traceDownNPCGround();
+
+        /**
          * @return The script-side handle to this NPC
          */
         Daedalus::GameState::NpcHandle getScriptHandle()
@@ -488,6 +493,14 @@ namespace Logic
 
             // Where the npc currently is looking at
             Math::float3 direction;
+
+            // Surface data obtained from raytracing the ground below NPC
+            struct
+            {
+                bool successful; // false if for some reason raytrace failed to hit the ground during last run
+                uint32_t triangleIndex;
+                Math::float3 trianglePosition;
+            } ground;
 
         }m_MoveState;
 

--- a/src/logic/visuals/ModelVisual.cpp
+++ b/src/logic/visuals/ModelVisual.cpp
@@ -106,6 +106,14 @@ const char* ANIMATION_NAMES[] = {
 	"T_FISTPARADEJUMPB", //ParadeFist_Back,
     "T_FIST_2_FISTRUN", // DrawFist,
 
+   // Swimming
+   "S_SWIM",
+   "S_SWIMB",
+   "S_SWIMF",
+   "T_SWIMTURNL",
+   "T_SWIMTURNR",
+   "T_SWIM_2_DIVE",
+   "T_SWIM_2_HANG",
 };
 
 ModelVisual::ModelVisual(World::WorldInstance& world, Handle::EntityHandle entity)

--- a/src/logic/visuals/ModelVisual.h
+++ b/src/logic/visuals/ModelVisual.h
@@ -97,7 +97,17 @@ namespace Logic
 			ParadeFist,
 			ParadeFist_Back,
 			DrawFist,
-			
+
+         // Swimming
+         Swim,
+         SwimB,
+         SwimF,
+         SwimTurnLeft,
+         SwimTurnRight,
+         SwimToDive,
+         SwimToHang, // No idea what that is, can't remember it from the original game
+
+         // Transitions
 			// TODO: Transitions, Running attacks, weapon walking, sneaking, backwards walking, attack while running, magic, other
 
 			NUM_ANIMATIONS


### PR DESCRIPTION
Implemented surface recognition under NPCs feet and basic swimming (there is no transitioning between ground and water yet and animation change is immediate.

I tried implementing improvised memoization system for caching functions output but applying caching to the surface type retrieval function resulted in no performance improvement, single invocation consumes roughly 15-20 microseconds with and without caching so I decided to leave it as it is for now. The generic memoization technique should be implemented either way for other use cases but is not crucial for this change.