### PR TITLE
Menu stacking and status screen toggle

### DIFF
--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -1859,12 +1859,18 @@ void PlayerController::setupKeyBindings()
     Engine::Input::clearActions();
 
     Engine::Input::RegisterAction(Engine::ActionType::OpenStatusMenu, [this](bool triggered, float) {
+
         if(triggered)
         {
-            UI::Menu_Status& statsScreen = m_World.getEngine()->getHud().pushMenu<UI::Menu_Status>();
-        
-            // Update the players status menu once
-            updateStatusScreen(statsScreen); 
+            UI::Hud &hud = m_World.getEngine()->getHud();
+            if (!hud.isTopMenu<UI::Menu_Status>())
+            {
+                UI::Menu_Status& statsScreen = hud.pushMenu<UI::Menu_Status>();
+
+                // Update the players status menu once
+                updateStatusScreen(statsScreen);
+            } else
+                hud.popMenu();
         }
     });
 

--- a/src/ui/Hud.h
+++ b/src/ui/Hud.h
@@ -1,6 +1,7 @@
 #pragma once
-#include "View.h"
 #include "Console.h"
+#include "Menu.h"
+#include "View.h"
 
 // HACK: Work around windows.h messing this up with its define
 #ifdef DialogBox
@@ -85,12 +86,18 @@ namespace UI
          * @tparam T Type of menu to append. Must have a static 'create' function!
          */
         template<typename T>
-        T& pushMenu() { m_MenuChain.push_back(T::create(m_Engine)); addChild((View*)m_MenuChain.back()); return *(T*)m_MenuChain.back(); }
+        T& pushMenu();
 
         /**
          * Pops the last menu from the chain and frees its memory.
          */
         void popMenu();
+
+        template <typename T>
+        bool isTopMenu()
+        {
+            return dynamic_cast<T*>(m_MenuChain.empty() ? nullptr : m_MenuChain.back()) != nullptr;
+        }
 
     protected:
 
@@ -135,4 +142,18 @@ namespace UI
          */
         std::vector<Menu*> m_RegisteredMenus;
     };
+
+    template <typename T>
+    inline T& Hud::pushMenu()
+    {
+        if (!m_MenuChain.empty() && dynamic_cast<T*>(m_MenuChain.back()) != nullptr)
+        {
+            return *static_cast<T*>(m_MenuChain.back());
+        }
+
+        T *menu = T::create(m_Engine);
+        m_MenuChain.push_back(menu);
+        addChild(m_MenuChain.back());
+        return *menu;
+    }
 }


### PR DESCRIPTION
Prevent multiple menus of the same type being stacked on top of each other (fixes having to close ESC multiple times)

Toggle status screen when pressing 'B'